### PR TITLE
Add email service with exception handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,17 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.3.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <version>3.2.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/be/technobel/corder/bl/MailService.java
+++ b/src/main/java/be/technobel/corder/bl/MailService.java
@@ -1,0 +1,8 @@
+package be.technobel.corder.bl;
+
+import java.util.Map;
+
+public interface MailService {
+    void sendMail(String to, String subject, String content, boolean isHtmlContent);
+    String buildEmailTemplate(String template, Map<String, Object> variables);
+}

--- a/src/main/java/be/technobel/corder/bl/impl/MailServiceImpl.java
+++ b/src/main/java/be/technobel/corder/bl/impl/MailServiceImpl.java
@@ -1,0 +1,48 @@
+package be.technobel.corder.bl.impl;
+
+import be.technobel.corder.bl.MailService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Map;
+
+@Service
+public class MailServiceImpl implements MailService {
+
+    private final JavaMailSender mailSender;
+
+    private final TemplateEngine templateEngine;
+
+    public MailServiceImpl(JavaMailSender mailSender, TemplateEngine templateEngine) {
+        this.mailSender = mailSender;
+        this.templateEngine = templateEngine;
+    }
+
+    @Override
+    public void sendMail(String to, String subject, String content, boolean isHtmlContent){
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message);
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(content, isHtmlContent);
+            mailSender.send(message);
+        }catch (MessagingException e) {
+            throw new MailSendException("Failed to send email", e);
+        }
+    }
+
+    @Override
+    public String buildEmailTemplate(String template, Map<String, Object> variables) {
+        Context context = new Context();
+        context.setVariables(variables);
+        return templateEngine.process(template, context);
+    }
+}

--- a/src/main/java/be/technobel/corder/bl/impl/ParticipationServiceImpl.java
+++ b/src/main/java/be/technobel/corder/bl/impl/ParticipationServiceImpl.java
@@ -1,5 +1,6 @@
 package be.technobel.corder.bl.impl;
 
+import be.technobel.corder.bl.MailService;
 import be.technobel.corder.bl.ParticipationService;
 import be.technobel.corder.dl.models.Address;
 import be.technobel.corder.dl.models.Participation;
@@ -15,15 +16,19 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class ParticipationServiceImpl implements ParticipationService {
 
     private final ParticipationRepository participationRepository;
+    private final MailService mailService;
 
-    public ParticipationServiceImpl(ParticipationRepository participationRepository) {
+    public ParticipationServiceImpl(ParticipationRepository participationRepository, MailService mailService) {
         this.participationRepository = participationRepository;
+        this.mailService = mailService;
     }
 
     private void isUniqueParticipant(Participation participation) {
@@ -66,6 +71,12 @@ public class ParticipationServiceImpl implements ParticipationService {
 
         participation.setStatus(Status.PENDING);
         participation.setParticipationDate(LocalDate.now());
+
+        //MAIL
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("greeting", "Merci " + participationForm.firstName() + " !");
+        String content = mailService.buildEmailTemplate("email-validation-template", variables);
+        mailService.sendMail(participationForm.email(), "Validation de la participation", content, true);
 
         return participationRepository.save(participation);
     }

--- a/src/main/java/be/technobel/corder/pl/controllers/controllerAdvice/ControllerAdvisor.java
+++ b/src/main/java/be/technobel/corder/pl/controllers/controllerAdvice/ControllerAdvisor.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mail.MailSendException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.FieldError;
@@ -73,6 +74,10 @@ public class ControllerAdvisor {
     @ExceptionHandler(InvalidPasswordException.class)
     public ResponseEntity<String> handleInvalidPasswordException(InvalidPasswordException e) {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+    @ExceptionHandler(MailSendException.class)
+    public ResponseEntity<String> handleMailSendException(MailSendException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.SERVICE_UNAVAILABLE);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,5 +17,12 @@ Spring:
       max-file-size: 5MB
       max-request-size: 5MB
 
+  mail:
+    host: ${SMTP_HOST}
+    port: ${SMTP_PORT}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+
+
 server:
   port: 8080

--- a/src/main/resources/templates/email-validation-template.html
+++ b/src/main/resources/templates/email-validation-template.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="fr">
+<body style="font-family: Calibri, sans-serif">
+<header>
+    <h1 th:text="${greeting}" style="color: rgb(45,109,110)">Merci!</h1>
+</header>
+<main>
+    <p>
+        Merci d’avoir rapporté vos déchets de pesticides au recyparc ! Dès que notre équipe aura validé votre photo, un kit de semences locales et biologiques Cycle-en-terre vous sera envoyé par la poste.
+    </p>
+    <p>
+        Et pour vous remercier de votre geste pour l’environnement, le 21 juin, un tirage au sort désignera un·e gagnant·e d’un bon cadeau de 200 € à dépenser en jardinerie labellisée "Jardiner Sans Pesticides". Le bon sera envoyé au·à la gagnant·e par mail. <span style="color: rgb(45,109,110)">Bonne chance!</span>
+    </p>
+    <p>
+        Pour découvrir les jardineries labellisées "Jardiner Sans Pesticides" sans plus attendre, rendez-vous sur <a href="https://www.jardinersanspesticides.be" style="color: rgb(45,109,110)">www.jardinersanspesticides.be</a>
+    </p>
+    <p>
+        Si vous souhaitez continuer à en apprendre plus sur le jardinage durable ou si vous vous posez des questions à ce propos, rendez-vous sur notre site web <a href="https://www.corder.be" style="color: rgb(45,109,110)">www.corder.be</a> ou par mail à <a href="mailto:info@corder.be" style="color: rgb(45,109,110)">info@corder.be</a> 🌱
+    </p>
+    <div style="text-align: right">
+        <p>
+            A Bientôt ! <br>
+            L'asbl CORDER
+        </p>
+        <p style="font-style: italic">
+            L’asbl CORDER s’intègre dans une série de démarches visant à favoriser la protection durable des végétaux en Wallonie
+        </p>
+    </div>
+</main>
+</body>
+</html>

--- a/src/test/java/be/technobel/corder/bl/impl/ParticipationServiceImplUnitTest.java
+++ b/src/test/java/be/technobel/corder/bl/impl/ParticipationServiceImplUnitTest.java
@@ -1,5 +1,6 @@
 package be.technobel.corder.bl.impl;
 
+import be.technobel.corder.bl.MailService;
 import be.technobel.corder.bl.ParticipationService;
 import be.technobel.corder.dl.models.Address;
 import be.technobel.corder.dl.models.Participation;
@@ -36,11 +37,12 @@ public class ParticipationServiceImplUnitTest {
 
     ParticipationRepository participationRepository;
     ParticipationServiceImpl participationService;
+    MailServiceImpl mailService;
 
     @BeforeEach
     public void setUp() {
         participationRepository = mock(ParticipationRepository.class);
-        participationService = new ParticipationServiceImpl(participationRepository);
+        participationService = new ParticipationServiceImpl(participationRepository, mailService);
     }
 
     @Test


### PR DESCRIPTION
A new mail service has been implemented, which allows for sending templated emails. The handling of MailSendException has been added to the ControllerAdvisor to manage potential errors in the mail sending process. Changes included also updating ParticipationServiceImpl and the unit testing accordingly. SMTP configuration section has been included in the application.yml file.